### PR TITLE
Add QUnit integration

### DIFF
--- a/addon/qunit.js
+++ b/addon/qunit.js
@@ -1,0 +1,34 @@
+import { expect, util } from 'chai';
+
+/**
+ * Returns a function that calls the passed in function with a wrapped
+ * expect() and the original `assert` as parameters.
+ */
+export function withChai(fn) {
+  return function(assert) {
+
+    function _expect(...args) {
+      let assertion = expect(...args);
+      let originalAssert = assertion.assert;
+      assertion.assert = function(...args) {
+        let message = util.flag(assertion, 'message');
+
+        try {
+          originalAssert.apply(this, args);
+          assert.pushResult({ result: true, message });
+
+        } catch (error) {
+          assert.pushResult({
+            result: false,
+            actual: error.showDiff ? error.actual : undefined,
+            expected: error.showDiff ? error.expected : undefined,
+            message: error.message,
+          });
+        }
+      };
+      return assertion;
+    }
+
+    return fn.call(this, _expect, assert);
+  };
+}

--- a/index.js
+++ b/index.js
@@ -20,6 +20,12 @@ module.exports = {
     app.import('vendor/shims/chai.js', { type: 'test' });
   },
 
+  treeForAddon: function() {
+    if (this.app.tests) {
+      return this._super.treeForAddon.apply(this, arguments);
+    }
+  },
+
   treeForVendor: function(tree) {
     var chaiPath = path.dirname(resolve.sync('chai'));
     var chaiTree = new Funnel(chaiPath, {

--- a/tests/acceptance/index-test.js
+++ b/tests/acceptance/index-test.js
@@ -1,0 +1,13 @@
+import { test } from 'qunit';
+import { withChai } from 'ember-cli-chai/qunit';
+import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
+
+moduleForAcceptance('Acceptance | index');
+
+test('visiting /', withChai(function(expect) {
+  visit('/');
+
+  andThen(function() {
+    expect(currentURL()).to.equal('/');
+  });
+}));

--- a/tests/unit/chai-test.js
+++ b/tests/unit/chai-test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
 import { expect } from 'chai';
+import { withChai } from 'ember-cli-chai/qunit';
 
 module('Chai.js');
 
@@ -8,3 +9,7 @@ test('it works', function(assert) {
   assert.throws(() => expect(true).to.be.false);
 });
 
+test('it has QUnit integration', withChai(function(expect) {
+  expect(true).to.be.true;
+  expect(5, '5 < 10').to.be.below(10);
+}));

--- a/vendor/shims/chai.js
+++ b/vendor/shims/chai.js
@@ -17,6 +17,7 @@ self.expect = self.chai.expect;
 
       config: self.chai.config,
       use: self.chai.use,
+      util: self.chai.util,
 
       Assertion: self.chai.Assertion,
       AssertionError: self.chai.AssertionError,


### PR DESCRIPTION
Example:

```js
import { module, test } from 'qunit';
import { withChai } from 'ember-cli-chai/qunit';

module('test');

test('it works', withChai(function(expect) {
  expect(5, '5 < 10').to.be.below(10);
}));
```

Resolves #3

/cc @lolmaus @akatov @mattmcmanus @justin-hackin