### PR TITLE
Import "chai-jquery" and "chai-dom" automatically if available

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,10 @@ module.exports = {
     this.importChaiJQuery =
       (dependencies.indexOf('chai-jquery') !== -1 || devDependencies.indexOf('chai-jquery') !== -1) &&
       checker.for('chai-jquery', 'npm').satisfies('^2.0.0');
+
+    this.importChaiDOM =
+      (dependencies.indexOf('chai-dom') !== -1 || devDependencies.indexOf('chai-dom') !== -1) &&
+      checker.for('chai-dom', 'npm').satisfies('^1.0.0');
   },
 
   included: function included(app) {
@@ -34,6 +38,9 @@ module.exports = {
 
     if (this.importChaiJQuery) {
       app.import('vendor/chai/chai-jquery.js', { type: 'test' });
+
+    } else if (this.importChaiDOM) {
+      app.import('vendor/chai/chai-dom.js', { type: 'test' });
     }
   },
 
@@ -60,6 +67,15 @@ module.exports = {
       });
 
       trees.push(chaiJQueryTree);
+
+    } else if (this.importChaiDOM) {
+      var chaiDOMPath = path.dirname(resolve.sync('chai-dom', { basedir: this.project.root }));
+      var chaiDOMTree = new Funnel(chaiDOMPath, {
+        files: ['chai-dom.js'],
+        destDir: '/chai',
+      });
+
+      trees.push(chaiDOMTree);
     }
 
     return new MergeTrees(trees, {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "broccoli-merge-trees": "^1.1.5",
     "chai": "^3.5.0",
     "ember-cli-babel": "^5.1.7",
+    "ember-cli-version-checker": "^1.1.7",
     "resolve": "^1.1.7"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",
+    "chai-jquery": "^2.0.0",
     "ember-ajax": "^2.4.1",
     "ember-cli": "2.9.1",
     "ember-cli-app-version": "^2.0.0",

--- a/tests/acceptance/index-test.js
+++ b/tests/acceptance/index-test.js
@@ -9,5 +9,6 @@ test('visiting /', withChai(function(expect) {
 
   andThen(function() {
     expect(currentURL()).to.equal('/');
+    expect(find('.test-element')).to.have.text('hello');
   });
 }));

--- a/tests/dummy/app/components/x-dummy.js
+++ b/tests/dummy/app/components/x-dummy.js
@@ -1,0 +1,5 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  foo: 'foo'
+});

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,0 +1,1 @@
+<div class="test-element">hello</div>

--- a/tests/dummy/app/templates/components/x-dummy.hbs
+++ b/tests/dummy/app/templates/components/x-dummy.hbs
@@ -1,0 +1,1 @@
+<div class="dummy foo">{{foo}}</div>

--- a/tests/integration/components/x-dummy-test.js
+++ b/tests/integration/components/x-dummy-test.js
@@ -1,0 +1,22 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import { withChai } from 'ember-cli-chai/qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('x-dummy', 'Integration | Component | x dummy', {
+  integration: true
+});
+
+test('it renders', withChai(function(expect) {
+  this.render(hbs`{{x-dummy}}`);
+
+  expect(this.$('.dummy'), 'has "foo" text').to.have.text('foo');
+}));
+
+test('it renders with attribute', withChai(function(expect) {
+  this.set('foo', 'bar');
+
+  this.render(hbs`{{x-dummy foo=foo}}`);
+
+  expect(this.$('.dummy'), 'has "bar" text').to.have.text('bar');
+  expect(this.$('.dummy'), 'has "foo" class').to.have.class('foo');
+}));


### PR DESCRIPTION
Example:

```js
expect(find('.test-element')).to.have.text('hello');
```

inspired by https://github.com/Dhaulagiri/ember-chai-jquery 👍 

/cc @dhaulagiri @trentmwillis