### PR TITLE
Update package.json to include qunit from 'addon' folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "author": "Jonathan kingston",
   "files": [
     "vendor",
+    "addon",
     "index.js"
   ],
   "directories": {


### PR DESCRIPTION
The withChai() integration was previously not exported as part of the npm module.