### PR TITLE
Configure tdChai shim to import td correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ test('it works', withChai(function(expect, assert) {
 - [`chai-dom`](https://github.com/nathanboktae/chai-dom) – DOM assertions
 - [`chai-as-promised`](https://github.com/domenic/chai-as-promised) – Promise assertions
 - [`sinon-chai`](https://github.com/domenic/sinon-chai) – Sinon assertions
+- [`testdouble-chai`](https://github.com/BaseCase/testdouble-chai) - testdouble.js assertions
 
 All you have to do is install those plugins via `npm install --save-dev`.
 Once they are installed and listed as dependencies in your `package.json` file

--- a/package.json
+++ b/package.json
@@ -57,6 +57,9 @@
     "node": ">= 4"
   },
   "ember-addon": {
-    "configPath": "tests/dummy/config"
+    "configPath": "tests/dummy/config",
+    "after": [
+      "ember-cli-testdouble"
+    ]
   }
 }

--- a/vendor/chai-plugin-support/testdouble-chai.js
+++ b/vendor/chai-plugin-support/testdouble-chai.js
@@ -1,3 +1,11 @@
+var td;
+
+try {
+  td = require('testdouble').default;
+} catch(e) {
+  td = window.td;
+}
+
 (function() {
   chai.use(tdChai(td));
 })();


### PR DESCRIPTION
Since `ember-cli-testdouble` now imports `testdouble` as a proper AMD
module, it no longer exposes the global that we were relying on. This
change tries import as a module first, falling back to the `window`
object instead.  It also tries to ensure that `ember-cli-testdouble`, if
installed, runs first, as suggested by @Turbo87.

Closes #28