### PR TITLE
Fix CI builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "ember-disable-prototype-extensions": "^1.1.2",
     "ember-load-initializers": "^1.0.0",
     "ember-resolver": "^4.0.0",
-    "ember-sinon": "^2.1.0",
+    "ember-sinon": "~2.1.0",
     "ember-source": "~2.17.0",
     "lerna-changelog": "^0.7.0",
     "loader.js": "^4.2.3",


### PR DESCRIPTION
`ember-sinon` v2.2.x changed the minimum Node requirement to Node 6 without bumping major, so we have to pin it to v2.1.x for now until we drop Node 4 support here too

/cc @elwayman02