### PR TITLE
CI: Remove obsolete `phantomjs-prebuilt` install step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ env:
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash
   - export PATH=$HOME/.yarn/bin:$PATH
-  - yarn global add phantomjs-prebuilt
 
 install:
   - yarn install --no-lockfile


### PR DESCRIPTION
We use headless Chrome now...