### PR TITLE
Remove obsolete `ember-cli-htmlbars-inline-precompile` dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "ember-cli-dependency-checker": "^3.2.0",
     "ember-cli-eslint": "^4.2.1",
     "ember-cli-htmlbars": "^4.0.8",
-    "ember-cli-htmlbars-inline-precompile": "^2.0.0",
     "ember-cli-inject-live-reload": "^2.0.1",
     "ember-cli-shims": "^1.2.0",
     "ember-disable-prototype-extensions": "^1.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3085,7 +3085,7 @@ ember-cli-get-component-path-option@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/ember-cli-get-component-path-option/-/ember-cli-get-component-path-option-1.0.0.tgz#0d7b595559e2f9050abed804f1d8eff1b08bc771"
 
-ember-cli-htmlbars-inline-precompile@^2.0.0, ember-cli-htmlbars-inline-precompile@^2.1.0:
+ember-cli-htmlbars-inline-precompile@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/ember-cli-htmlbars-inline-precompile/-/ember-cli-htmlbars-inline-precompile-2.1.0.tgz#61b91ff1879d44ae504cadb46fb1f2604995ae08"
   dependencies:


### PR DESCRIPTION
`ember-cli-htmlbars` takes care of this now